### PR TITLE
add zen assignment 2 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ People
 * [Samantha Yip](people/samantha-yip.md) - sty5 - [http://aws-website-sty-mksjo.s3-website-us-east-1.amazonaws.com/grading.html](http://aws-website-sty-mksjo.s3-website-us-east-1.amazonaws.com/grading.html)
 * [Jamie Yu](people/jamie-yu.md) - jky32 - [https://d1l2obcta6wa23.cloudfront.net/grading.html](https://d1l2obcta6wa23.cloudfront.net/grading.html)
 * [Tao Yuan](people/tao-yuan.md) - ty353 - [https://s3.amazonaws.com/taoyuanbayernstar.com/grading.html](https://s3.amazonaws.com/taoyuanbayernstar.com/grading.html)
-* [Zen Yui](people/zen-yui.md) - jzy6 - [https://s3.amazonaws.com/jzy.io/grading.html](https://s3.amazonaws.com/jzy.io/grading.html)
+* [Zen Yui](people/zen-yui.md) - jzy6 - [http://cs5356-a2.jzy.io](http://cs5356-a2.jzy.io)[![CircleCI](https://circleci.com/gh/zenyui/cs5356-a2/tree/master.svg?style=svg&circle-token=49df7ca1f811e8e6a4a917e3cc0937a7d25e3d28)](https://circleci.com/gh/zenyui/cs5356-a2/tree/master)
 * [Renee Zacharowicz](people/renee-zacharowicz.md) - rz336 - [https://s3.us-east-2.amazonaws.com/estherai.xyz/grading.html](https://s3.us-east-2.amazonaws.com/estherai.xyz/grading.html)
 * [Hanyu Zhang](people/hanyu-zhang.md) - hz464 - [https://s3.us-east-2.amazonaws.com/ppppppppppppg.com/grading.html](https://s3.us-east-2.amazonaws.com/ppppppppppppg.com/grading.html) [![CircleCI](https://circleci.com/gh/PGhzhang/skeleton.svg?style=svg)](https://circleci.com/gh/PGhzhang/skeleton)
 * [Weisi Zhang](people/weisi-zhang.md) - wz337 - [http://weisizhang-ej31m.com.s3-website-us-east-1.amazonaws.com/grading.html](http://weisizhang-ej31m.com.s3-website-us-east-1.amazonaws.com/grading.html)


### PR DESCRIPTION
API is up in EC2 cluster.

Pointed my domain at the cluster ([http://cs5356-a2.jzy.io](http://cs5356-a2.jzy.io)).  Let me know if it works on your end (I had issues with cornell's DNS cache for assignment 1.